### PR TITLE
add workaround for microsoft ssh clone requirements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/monocoque/simulatorapi/simapi"]
 	path = src/monocoque/simulatorapi/simapi
-	url = git@github.com:spacefreak18/simapi
+	url = https://github.com/spacefreak18/simapi
+	# url = git@github.com:spacefreak18/simapi # ssh is better but Microsoft requires an account

--- a/README.md
+++ b/README.md
@@ -44,29 +44,6 @@ cmake ..
 make
 ```
 
-### A note about GitHub's ssh cloning policy
-
-if you do not have an ssh key set up in you environment that is registered to a GitHub account, Microsoft will decline the clone request and you'll see a permission error like this:
-
-```
-git@github.com: Permission denied (publickey).
-fatal: Could not read from remote repository.
-
-Please make sure you have the correct access rights
-and the repository exists.
-```
-
-to get around this, first clone the repository over https, then modify the `.gitmodules` file locally such that ssh urls are replaced with https urls.
-You can then continue on to sync and update submodules.
-
-```
-git clone https://github.com/Spacefreak18/monocoque
-cd monocoque
-# vim .gitmodules
-git submodule sync --recursive
-git submodule update --init --recursive
-```
-
 ## Testing
 
 ### Setting up Your Arduino Device

--- a/README.md
+++ b/README.md
@@ -36,12 +36,37 @@ This code depends on the shared memory data headers in the simapi [repo](https:/
 git submodule sync --recursive
 git submodule update --init --recursive
 ```
+
 Then to compile simply:
 ```
 mkdir build; cd build
 cmake ..
 make
 ```
+
+### A note about GitHub's ssh cloning policy
+
+if you do not have an ssh key set up in you environment that is registered to a GitHub account, Microsoft will decline the clone request and you'll see a permission error like this:
+
+```
+git@github.com: Permission denied (publickey).
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+```
+
+to get around this, first clone the repository over https, then modify the `.gitmodules` file locally such that ssh urls are replaced with https urls.
+You can then continue on to sync and update submodules.
+
+```
+git clone https://github.com/Spacefreak18/monocoque
+cd monocoque
+# vim .gitmodules
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
 ## Testing
 
 ### Setting up Your Arduino Device


### PR DESCRIPTION
Just a heads up that this doesn't clone properly without a github-registered ssh key. modified readme with a workaround.