### PR TITLE
Initial support for latest Moza firmware LED controls

### DIFF
--- a/src/monocoque/devices/CMakeLists.txt
+++ b/src/monocoque/devices/CMakeLists.txt
@@ -38,6 +38,8 @@ set(devices_source_files
   serial/arduinoledlua.c
   serial/moza.h
   serial/moza.c
+  serial/moza_new.h
+  serial/moza_new.c
 )
 
 include_directories("." "usb" "sound" "serial")

--- a/src/monocoque/devices/serial/moza.c
+++ b/src/monocoque/devices/serial/moza.c
@@ -17,10 +17,10 @@
 #define MOZA_MAGIC_VALUE 0x0d
 #define BIT(nr) (1UL << (nr))
 
-unsigned char moza_checksum(unsigned char *data)
+unsigned char moza_checksum(unsigned char *data, unsigned short size)
 {
     unsigned int ret = MOZA_MAGIC_VALUE;
-    for (short i = 0; i < MOZA_PAYLOAD_SIZE; i++)
+    for (unsigned short i = 0; i < size; i++)
     {
         ret += data[i];
     }
@@ -31,7 +31,7 @@ unsigned char moza_checksum(unsigned char *data)
 int moza_update(SerialDevice* serialdevice, unsigned short maxrpm, unsigned short rpm)
 {
     unsigned char bytes[] = MOZA_SERIAL_TEMPLATE;
-    int size = MOZA_PAYLOAD_SIZE;
+    unsigned short size = MOZA_PAYLOAD_SIZE;
     float perctflt = ((float)rpm/(float)maxrpm)*100;
     int perct = round(perctflt);
 
@@ -69,7 +69,7 @@ int moza_update(SerialDevice* serialdevice, unsigned short maxrpm, unsigned shor
     if (perct >= 94)
         bytes[8] |= BIT(MOZA_BLINKING_BIT);
 
-    bytes[10] = moza_checksum(bytes);
+    bytes[10] = moza_checksum(bytes, size);
 
     int result = 1;
     if (serialdevice->port)

--- a/src/monocoque/devices/serial/moza.h
+++ b/src/monocoque/devices/serial/moza.h
@@ -6,8 +6,6 @@
 
 int moza_update(SerialDevice* serialdevice, unsigned short maxrpm, unsigned short rpm);
 int moza_init(SerialDevice* serialdevice, const char* portdev);
-int moza_free(SerialDevice* serialdevice);
-int moza_serial_check(enum sp_return result);
-
+unsigned char moza_checksum(unsigned char *data, unsigned short size);
 
 #endif

--- a/src/monocoque/devices/serial/moza_new.c
+++ b/src/monocoque/devices/serial/moza_new.c
@@ -1,0 +1,96 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+#include <hidapi/hidapi.h>
+
+#include "moza.h"
+#include "moza_new.h"
+#include "../serialadapter.h"
+#include "../../slog/slog.h"
+
+#define MOZA_TIMEOUT 1000
+#define MOZA_MAGIC_VALUE 0x0d
+#define MOZA_RPM_MASK_TEMPLATE {0x7e, 0x06, 0x3f, 0x17, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+#define MOZA_RPM_MASK_PAYLOAD_SIZE 11
+#define MOZA_RPM_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0, 0xff, 0, 1, 0, 0xff, 0, 2, 0, 0xff, 0, 3, 0xff, 0x7f, 0, 4, 0xff, 0x7f, 0, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 5, 0xff, 0x7f, 0, 6, 0xff, 0x7f, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
+#define MOZA_BTN_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 0, 0xff, 0, 0, 1, 0xff, 0, 0, 2, 0xff, 0, 0, 3, 0xff, 0, 0, 4, 0xff, 0, 0, 0}
+#define MOZA_BTN_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 5, 0xff, 0, 0, 6, 0xff, 0, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
+#define MOZA_COLOR_PAYLOAD_SIZE 27
+#define BIT(nr) (1UL << (nr))
+
+int moza_new_update(SerialDevice* serialdevice, SimData* simData)
+{
+    unsigned char bytes[] = MOZA_RPM_MASK_TEMPLATE;
+    int size = MOZA_RPM_MASK_PAYLOAD_SIZE;
+    float perctflt = ((float)simData->rpms/(float)simData->maxrpm)*100;
+    int perct = round(perctflt);
+    if (perct >= 98 && (simData->mtick >> 7) & 1 == 1) perct = 0;
+
+    if (perct >= 75)
+        bytes[6] |= BIT(0);
+
+    if (perct >= 79)
+        bytes[6] |= BIT(1);
+
+    if (perct >= 82)
+        bytes[6] |= BIT(2);
+
+    if (perct >= 85)
+        bytes[6] |= BIT(3);
+
+    if (perct >= 87)
+        bytes[6] |= BIT(4);
+
+    if (perct >= 88)
+        bytes[6] |= BIT(5);
+
+    if (perct >= 89)
+        bytes[6] |= BIT(6);
+
+    if (perct >= 90)
+        bytes[6] |= BIT(7);
+
+    if (perct >= 92)
+        bytes[7] |= BIT(0);
+
+    if (perct >= 94)
+        bytes[7] |= BIT(1);
+
+    bytes[10] = moza_checksum(bytes, size);
+
+    int result = 1;
+    if (serialdevice->port)
+    {
+        slogd("copying %i bytes to moza device", MOZA_RPM_MASK_PAYLOAD_SIZE);
+        slogt("writing bytes %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x from rpm %i maxrpm %i", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], simData->rpms, simData->maxrpm);
+        result = monocoque_serial_write(serialdevice->id, bytes, size, MOZA_TIMEOUT);
+    }
+
+    return result;
+}
+
+int moza_new_init(SerialDevice* serialdevice, const char* portdev)
+{
+    serialdevice->id = monocoque_serial_open(serialdevice, portdev);
+    if (serialdevice->id == -1) return serialdevice->id;
+
+    unsigned char p1[] = MOZA_RPM_COLOR_PAYLOAD_1;
+    unsigned char p2[] = MOZA_RPM_COLOR_PAYLOAD_2;
+    unsigned char p3[] = MOZA_BTN_COLOR_PAYLOAD_1;
+    unsigned char p4[] = MOZA_BTN_COLOR_PAYLOAD_2;
+
+    p1[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p1, MOZA_COLOR_PAYLOAD_SIZE);
+    p2[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p2, MOZA_COLOR_PAYLOAD_SIZE);
+    p3[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p3, MOZA_COLOR_PAYLOAD_SIZE);
+    p4[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p4, MOZA_COLOR_PAYLOAD_SIZE);
+
+    monocoque_serial_write(serialdevice->id, p1, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p2, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p3, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p4, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+
+    return serialdevice->id;
+}

--- a/src/monocoque/devices/serial/moza_new.h
+++ b/src/monocoque/devices/serial/moza_new.h
@@ -1,0 +1,10 @@
+#ifndef _MOZA_NEW_H
+#define _MOZA_NEW_H
+
+#include "../serialdevice.h"
+#include "../simdevice.h"
+
+int moza_new_update(SerialDevice* serialdevice, SimData* simData);
+int moza_new_init(SerialDevice* serialdevice, const char* portdev);
+
+#endif

--- a/src/monocoque/devices/serialdevice.h
+++ b/src/monocoque/devices/serialdevice.h
@@ -12,7 +12,8 @@ typedef enum
     SERIALDEV__MOZAR5                 = 3,
     ARDUINODEV__SIMLED                = 4,
     ARDUINODEV__SIMLED__CUSTOM        = 5,
-    ARDUINODEV__CUSTOM                = 6
+    ARDUINODEV__CUSTOM                = 6,
+    SERIALDEV__MOZA_NEW               = 7
 }
 SerialDeviceType;
 

--- a/src/monocoque/helper/confighelper.c
+++ b/src/monocoque/helper/confighelper.c
@@ -93,6 +93,11 @@ int strtodevsubsubtype(const char* device_subsubtype, DeviceSettings* ds)
         ds->dev_subsubtype = SIMDEVSUBTYPE_CAMMUSC12;
         devfound = true;
     }
+    if (strcicmp(device_subsubtype, "MozaNew") == 0)
+    {
+        ds->dev_subsubtype = SIMDEVSUBTYPE_MOZA_NEW;
+        devfound = true;
+    }
     if (strcicmp(device_subsubtype, "MozaR5") == 0)
     {
         ds->dev_subsubtype = SIMDEVSUBTYPE_MOZAR5;
@@ -811,6 +816,12 @@ int devsetup(const char* device_type, const char* device_subtype, const char* co
         if (device_settings != NULL)
         {
             const char* temp;
+            int found = config_setting_lookup_string(device_settings, "subtype", &temp);
+            if(temp != NULL && found > 0)
+            {
+              strtodevsubsubtype(temp, ds);
+            }
+
             config_setting_lookup_string(device_settings, "devpath", &temp);
             ds->serialdevsettings.portdev = strdup(temp);
 
@@ -840,7 +851,7 @@ int devsetup(const char* device_type, const char* device_subtype, const char* co
 
             double ampfactor = 1.0;
             ds->serialdevsettings.ampfactor = 1.0;
-            int found = config_setting_lookup_float(device_settings, "ampfactor", &ampfactor);
+            found = config_setting_lookup_float(device_settings, "ampfactor", &ampfactor);
             ds->serialdevsettings.ampfactor = ampfactor;
 
             slogt("set port baud rate to %i, ampfactor %f", baud, ampfactor);

--- a/src/monocoque/helper/confighelper.h
+++ b/src/monocoque/helper/confighelper.h
@@ -43,7 +43,8 @@ typedef enum
     SIMDEVSUBTYPE_MOZAR5                  = 3,
     SIMDEVSUBTYPE_CSLELITEV3PEDALS        = 4,
     SIMDEVSUBTYPE_SIMAGICP1000PEDALS      = 5,
-    SIMDEVSUBTYPE_SIMAGICGTNEO            = 6
+    SIMDEVSUBTYPE_SIMAGICGTNEO            = 6,
+    SIMDEVSUBTYPE_MOZA_NEW                = 7
 }
 DeviceSubSubType;
 


### PR DESCRIPTION
This adds support for RPM LEDs on Moza wheels that are running the latest firmware.

Recent Moza firmware updates appear to have changed the way that LEDs are controlled, so the current mechanism in moza.c doesn't work any more.

This adds a new sub-sub-type, "MozaNew" (happy to take feedback on naming), and a parallel implementation (moza_new.c) for the newest firmware revision. The old "MozaR5" sub-sub-type is still present and should work for folks who have wheels running older firmware although I don't have one of these to test with.

As it currently is implemented, this driver sets all the button backlights to red at startup and controls RPM LEDs using hard-coded LED colors and the default "normal" timings from Pithouse / Boxflat.

Short video of this in action: https://youtube.com/shorts/8Qkra1Ly5YU