### PR TITLE
Calculate suspension velocity for ac

### DIFF
--- a/src/monocoque/devices/hapticeffect.c
+++ b/src/monocoque/devices/hapticeffect.c
@@ -415,6 +415,42 @@ double slipeffect(SimData* simdata, int effecttype, int tyre, double threshold, 
                 }
             }
             break;
+
+        case (EFFECT_SUSPENSIONVELOCITY):
+
+            if (tyre == FRONTLEFT || tyre == FRONTS || tyre == ALLFOUR)
+            {
+                if(simdata->suspvelocity[0] > threshold)
+                {
+                    play += simdata->suspvelocity[0] - threshold;
+                    slogt("suspension velocity is %f", play);
+                }
+            }
+            if (tyre == FRONTRIGHT || tyre == FRONTS || tyre == ALLFOUR)
+            {
+                if(simdata->suspvelocity[1] > threshold)
+                {
+                    play += simdata->suspvelocity[1] - threshold;
+                    slogt("suspension velocity is %f", play);
+                }
+            }
+            if (tyre == REARLEFT || tyre == REARS || tyre == ALLFOUR)
+            {
+                if(simdata->suspvelocity[2] > threshold)
+                {
+                    play += simdata->suspvelocity[2] - threshold;
+                    slogt("suspension velocity is %f", play);
+                }
+            }
+            if (tyre == REARRIGHT || tyre == REARS || tyre == ALLFOUR)
+            {
+                if(simdata->suspvelocity[3] > threshold)
+                {
+                    play += simdata->suspvelocity[3] - threshold;
+                    slogt("suspension velocity is %f", play);
+                }
+            }
+            break;
     }
 
     return play;

--- a/src/monocoque/devices/sounddevice.c
+++ b/src/monocoque/devices/sounddevice.c
@@ -145,6 +145,25 @@ int sounddev_suspension_update(SimDevice* this, SimData* simdata)
 
 }
 
+int sounddev_suspensionvelocity_update(SimDevice* this, SimData* simdata)
+{
+    SoundDevice* sounddevice = (void *) this->derived;
+
+    double effect = slipeffect(simdata, this->hapticeffect.effecttype, this->hapticeffect.tyre, this->hapticeffect.threshold, this->hapticeffect.useconfig, this->hapticeffect.configcheck, this->hapticeffect.tyrediameterconfig);
+    slogt("Updating sound device output from suspension velocity effect %f", effect);
+
+    if (effect > 0)
+    {
+        effect = modulate(sounddevice, effect, sounddevice->modulationType);
+    }
+    else
+    {
+        sounddevice->sounddata.curr_frequency = 0.0;
+        sounddevice->sounddata.curr_amplitude = 0;
+        sounddevice->sounddata.curr_duration = 0;
+    }
+}
+
 int sounddev_gearshift_update(SimDevice* this, SimData* simdata)
 {
     SoundDevice* sounddevice = (void *) this->derived;
@@ -213,6 +232,9 @@ int sounddev_init(SoundDevice* sounddevice, const char* devname, MonocoqueTyreId
         case (EFFECT_SUSPENSION):
             streamname = "Suspension";
             break;
+        case (EFFECT_SUSPENSIONVELOCITY):
+            streamname = "SuspensionVelocity";
+            break;
         case (EFFECT_ENGINERPM):
         default:
             streamname = "Engine";
@@ -230,6 +252,7 @@ static const vtable tyreslip_sound_simdevice_vtable = { &sounddev_tyreslip_updat
 static const vtable tyrelock_sound_simdevice_vtable = { &sounddev_tyrelock_update, &sounddev_free };
 static const vtable absbrakes_sound_simdevice_vtable = { &sounddev_absbrakes_update, &sounddev_free };
 static const vtable suspension_sound_simdevice_vtable = { &sounddev_suspension_update, &sounddev_free };
+static const vtable suspensionvelocity_sound_simdevice_vtable = { &sounddev_suspensionvelocity_update, &sounddev_free };
 
 SoundDevice* new_sound_device(DeviceSettings* ds, MonocoqueSettings* ms, SimInfo* siminfo) {
 
@@ -246,6 +269,7 @@ SoundDevice* new_sound_device(DeviceSettings* ds, MonocoqueSettings* ms, SimInfo
         case (EFFECT_TYRELOCK):
         case (EFFECT_ABSBRAKES):
         case (EFFECT_SUSPENSION):
+        case (EFFECT_SUSPENSIONVELOCITY):
             if(siminfo->SimSupportsHapticEffects == false)
             {
                 slogw("Skipping sound effect setup because sim does not support haptic effects");
@@ -314,6 +338,16 @@ SoundDevice* new_sound_device(DeviceSettings* ds, MonocoqueSettings* ms, SimInfo
                 slogi("Initializing sound device for abs vibrations.");
                 break;
 
+            case (EFFECT_SUSPENSIONVELOCITY):
+                this->m.hapticeffect.effecttype = EFFECT_SUSPENSIONVELOCITY;
+                this->m.hapticeffect.threshold = ds->threshold;
+                this->m.hapticeffect.tyre = ds->tyre;
+                this->m.hapticeffect.useconfig = ms->useconfig;
+                this->m.hapticeffect.configcheck = &ms->configcheck;
+                this->m.hapticeffect.tyrediameterconfig = ms->tyre_diameter_config;
+                this->m.vtable = &suspensionvelocity_sound_simdevice_vtable;
+                slogi("Initializing sound device for suspension velocity vibrations.");
+                break;
             case (EFFECT_SUSPENSION):
                 this->m.hapticeffect.effecttype = EFFECT_SUSPENSION;
                 this->m.hapticeffect.threshold = ds->threshold;

--- a/src/monocoque/helper/confighelper.c
+++ b/src/monocoque/helper/confighelper.c
@@ -49,6 +49,11 @@ int strtoeffecttype(const char* effect, DeviceSettings* ds)
         ds->is_valid = true;
         ds->effect_type = EFFECT_SUSPENSION;
     }
+    if (strcicmp(effect, "SuspensionVelocity") == 0)
+    {
+        ds->is_valid = true;
+        ds->effect_type = EFFECT_SUSPENSIONVELOCITY;
+    }
     if (strcicmp(effect, "ABS") == 0)
     {
         ds->is_valid = true;
@@ -734,7 +739,7 @@ int devsetup(const char* device_type, const char* device_subtype, const char* co
         const char* effect;
         config_setting_lookup_string(device_settings, "effect", &effect);
         strtoeffecttype(effect, ds);
-        if (ds->effect_type == EFFECT_TYRESLIP || ds->effect_type == EFFECT_TYRELOCK || ds->effect_type == EFFECT_ABSBRAKES || ds->effect_type == EFFECT_SUSPENSION )
+        if (ds->effect_type == EFFECT_TYRESLIP || ds->effect_type == EFFECT_TYRELOCK || ds->effect_type == EFFECT_ABSBRAKES || ds->effect_type == EFFECT_SUSPENSION || ds->effect_type == EFFECT_SUSPENSIONVELOCITY )
         {
             gettyre(device_settings, ds);
             ds->threshold = 0;

--- a/src/monocoque/helper/confighelper.h
+++ b/src/monocoque/helper/confighelper.h
@@ -63,12 +63,13 @@ SimulatorUpdate;
 
 typedef enum
 {
-    EFFECT_ENGINERPM   = 0,
-    EFFECT_GEARSHIFT   = 1,
-    EFFECT_ABSBRAKES   = 2,
-    EFFECT_TYRESLIP    = 3,
-    EFFECT_TYRELOCK    = 4,
-    EFFECT_SUSPENSION  = 5
+    EFFECT_ENGINERPM          = 0,
+    EFFECT_GEARSHIFT          = 1,
+    EFFECT_ABSBRAKES          = 2,
+    EFFECT_TYRESLIP           = 3,
+    EFFECT_TYRELOCK           = 4,
+    EFFECT_SUSPENSION         = 5,
+    EFFECT_SUSPENSIONVELOCITY = 6
 }
 VibrationEffectType;
 


### PR DESCRIPTION
The suspension velocity in the sim data isn't currently plumbed through to provide haptic effects, so this change implements that.

The changes I raised against simapi for the acmapper allow the effects to work from AC.

Example config used to test

```
{
    device       = "Sound";
    effect       = "SuspensionVelocity";
    tyre         = "FrontLeft";
    devid        = "alsa_output.usb-C-Media_Electronics_Inc._USB_Audio_Device-00.analog-stereo";
    pan          = 0;
    fps          = 60;
    threshold    = 0.2;
    channels     = 2;
    volume       = 70;
    modulation   = "frequency";
    frequency    = 35;
    frequencyMax = 55;
    duration     = 0.15;
    noise        = 3;
}
```