### PR TITLE
Feat add moza ks pro wheel

### DIFF
--- a/src/monocoque/devices/CMakeLists.txt
+++ b/src/monocoque/devices/CMakeLists.txt
@@ -42,6 +42,8 @@ set(devices_source_files
   serial/moza.c
   serial/moza_new.h
   serial/moza_new.c
+  serial/moza_ks_pro_wheel.h
+  serial/moza_ks_pro_wheel.c
 )
 
 include_directories("." "usb" "sound" "serial")

--- a/src/monocoque/devices/serial/moza_ks_pro_wheel.c
+++ b/src/monocoque/devices/serial/moza_ks_pro_wheel.c
@@ -14,9 +14,9 @@
 #define MOZA_MAGIC_VALUE 0x0d
 #define MOZA_RPM_MASK_TEMPLATE {0x7e, 0x06, 0x3f, 0x17, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
 #define MOZA_RPM_MASK_PAYLOAD_SIZE 11
-#define MOZA_RPM_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0, 0xff, 0, 1, 0, 0xff, 0, 2, 0, 0xff, 0, 3, 0xff, 0x7f, 0, 4, 0xff, 0x7f, 0, 0}
-#define MOZA_RPM_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 5, 0xff, 0x7f, 0, 6, 0xff, 0x7f, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
-#define MOZA_RPM_COLOR_PAYLOAD_3 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 10, 0, 0, 0xff, 11, 0, 0, 0xff, 12, 0, 0, 0xff, 13, 0, 0, 0xff, 14, 0, 0, 0xff, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0xff, 0, 0, 4, 0xff, 0, 0, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 5, 0xff, 0, 0, 6, 0xff, 0, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_3 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 10, 0xff, 0x7f, 0, 11, 0xff, 0x7f, 0, 12, 0xff, 0x7f, 0, 13, 0, 0, 0xff, 14, 0, 0, 0xff, 0}
 #define MOZA_BTN_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 0, 0xff, 0, 0, 1, 0xff, 0, 0, 2, 0xff, 0, 0, 3, 0xff, 0, 0, 4, 0xff, 0, 0, 0}
 #define MOZA_BTN_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 5, 0xff, 0, 0, 6, 0xff, 0, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
 #define MOZA_COLOR_PAYLOAD_SIZE 27
@@ -30,50 +30,43 @@ int moza_ks_pro_wheel_update(SerialDevice* serialdevice, SimData* simData)
     int perct = round(perctflt);
     if (perct >= 98 && (simData->mtick >> 7) & 1 == 1) perct = 0;
 
+
     if (perct >= 75)
-        bytes[6] |= BIT(0);
-
-    if (perct >= 79)
-        bytes[6] |= BIT(1);
-
-    if (perct >= 82)
-        bytes[6] |= BIT(2);
-
-    if (perct >= 85)
         bytes[6] |= BIT(3);
 
-    if (perct >= 87)
+    if (perct >= 77)
         bytes[6] |= BIT(4);
 
-    if (perct >= 88)
+    if (perct >= 79)
         bytes[6] |= BIT(5);
 
-    if (perct >= 89)
+    if (perct >= 81)
         bytes[6] |= BIT(6);
 
-    if (perct >= 90)
+    if (perct >= 83)
         bytes[6] |= BIT(7);
 
-    if (perct >= 92)
+    if (perct >= 85)
         bytes[7] |= BIT(0);
 
-    if (perct >= 94)
+    if (perct >= 87)
         bytes[7] |= BIT(1);
 
-    if (perct >= 95)
+    if (perct >= 89)
         bytes[7] |= BIT(2);
 
-    if (perct >= 96)
+    if (perct >= 91)
         bytes[7] |= BIT(3);
 
-    if (perct >= 97)
+    if (perct >= 93)
         bytes[7] |= BIT(4);
 
-    if (perct >= 98)
+    if (perct >= 95)
         bytes[7] |= BIT(5);
 
-    if (perct >= 99)
+    if (perct >= 97)
         bytes[7] |= BIT(6);
+
 
     bytes[10] = moza_checksum(bytes, size);
 

--- a/src/monocoque/devices/serial/moza_ks_pro_wheel.c
+++ b/src/monocoque/devices/serial/moza_ks_pro_wheel.c
@@ -20,10 +20,15 @@
 #define MOZA_BTN_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 0, 0xff, 0, 0, 1, 0xff, 0, 0, 2, 0xff, 0, 0, 3, 0xff, 0, 0, 4, 0xff, 0, 0, 0}
 #define MOZA_BTN_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 5, 0xff, 0, 0, 6, 0xff, 0, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
 #define MOZA_COLOR_PAYLOAD_SIZE 27
+#define MOZA_FLAG_COLOR_YELLOW_LEFT  {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0xff, 0xaa, 0, 1, 0xff, 0xaa, 0, 2, 0xff, 0xaa, 0, 0, 0xff, 0xaa, 0, 1, 0xff, 0xaa, 0, 0}
+#define MOZA_FLAG_COLOR_YELLOW_RIGHT {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 15, 0xff, 0xaa, 0, 16, 0xff, 0xaa, 0, 17, 0xff, 0xaa, 0, 15, 0xff, 0xaa, 0, 16, 0xff, 0xaa, 0, 0}
+#define MOZA_FLAG_COLOR_OFF_LEFT     {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0}
+#define MOZA_FLAG_COLOR_OFF_RIGHT    {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 15, 0, 0, 0, 16, 0, 0, 0, 17, 0, 0, 0, 15, 0, 0, 0, 16, 0, 0, 0, 0}
 #define BIT(nr) (1UL << (nr))
 
 int moza_ks_pro_wheel_update(SerialDevice* serialdevice, SimData* simData)
 {
+    static uint8_t last_flag = 0xff;
     unsigned char bytes[] = MOZA_RPM_MASK_TEMPLATE;
     int size = MOZA_RPM_MASK_PAYLOAD_SIZE;
     float perctflt = ((float)simData->rpms/(float)simData->maxrpm)*100;
@@ -68,11 +73,36 @@ int moza_ks_pro_wheel_update(SerialDevice* serialdevice, SimData* simData)
         bytes[7] |= BIT(6);
 
 
+    if (simData->playerflag == SIMAPI_FLAG_YELLOW) {
+        bytes[6] |= BIT(0) | BIT(1) | BIT(2);  // left 3 flag LEDs (indices 0, 1, 2)
+        bytes[7] |= BIT(7);                      // right flag LED (index 15)
+        bytes[8] |= BIT(0) | BIT(1);            // right flag LEDs (indices 16, 17)
+    }
+
     bytes[10] = moza_checksum(bytes, size);
 
     int result = 1;
     if (serialdevice->port)
     {
+        if (simData->playerflag != last_flag) {
+            last_flag = simData->playerflag;
+            if (simData->playerflag == SIMAPI_FLAG_YELLOW) {
+                unsigned char fl[] = MOZA_FLAG_COLOR_YELLOW_LEFT;
+                unsigned char fr[] = MOZA_FLAG_COLOR_YELLOW_RIGHT;
+                fl[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(fl, MOZA_COLOR_PAYLOAD_SIZE);
+                fr[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(fr, MOZA_COLOR_PAYLOAD_SIZE);
+                monocoque_serial_write(serialdevice->id, fl, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+                monocoque_serial_write(serialdevice->id, fr, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+            } else {
+                unsigned char fl[] = MOZA_FLAG_COLOR_OFF_LEFT;
+                unsigned char fr[] = MOZA_FLAG_COLOR_OFF_RIGHT;
+                fl[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(fl, MOZA_COLOR_PAYLOAD_SIZE);
+                fr[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(fr, MOZA_COLOR_PAYLOAD_SIZE);
+                monocoque_serial_write(serialdevice->id, fl, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+                monocoque_serial_write(serialdevice->id, fr, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+            }
+        }
+
         slogd("copying %i bytes to moza device", MOZA_RPM_MASK_PAYLOAD_SIZE);
         slogt("writing bytes %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x from rpm %i maxrpm %i", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], simData->rpms, simData->maxrpm);
         result = monocoque_serial_write(serialdevice->id, bytes, size, MOZA_TIMEOUT);
@@ -103,6 +133,10 @@ int moza_ks_pro_wheel_init(SerialDevice* serialdevice, const char* portdev)
     monocoque_serial_write(serialdevice->id, p3, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
     monocoque_serial_write(serialdevice->id, p4, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
     monocoque_serial_write(serialdevice->id, p5, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+
+    unsigned char p6[] = MOZA_FLAG_COLOR_OFF_RIGHT;
+    p6[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p6, MOZA_COLOR_PAYLOAD_SIZE);
+    monocoque_serial_write(serialdevice->id, p6, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
 
     return serialdevice->id;
 }

--- a/src/monocoque/devices/serial/moza_ks_pro_wheel.c
+++ b/src/monocoque/devices/serial/moza_ks_pro_wheel.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+#include <hidapi/hidapi.h>
+
+#include "moza.h"
+#include "moza_ks_pro_wheel.h"
+#include "../serialadapter.h"
+#include "../../slog/slog.h"
+
+#define MOZA_TIMEOUT 1000
+#define MOZA_MAGIC_VALUE 0x0d
+#define MOZA_RPM_MASK_TEMPLATE {0x7e, 0x06, 0x3f, 0x17, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+#define MOZA_RPM_MASK_PAYLOAD_SIZE 11
+#define MOZA_RPM_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 0, 0, 0xff, 0, 1, 0, 0xff, 0, 2, 0, 0xff, 0, 3, 0xff, 0x7f, 0, 4, 0xff, 0x7f, 0, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 5, 0xff, 0x7f, 0, 6, 0xff, 0x7f, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
+#define MOZA_RPM_COLOR_PAYLOAD_3 {0x7e, 0x16, 0x3f, 0x17, 0x19, 0, 10, 0, 0, 0xff, 11, 0, 0, 0xff, 12, 0, 0, 0xff, 13, 0, 0, 0xff, 14, 0, 0, 0xff, 0}
+#define MOZA_BTN_COLOR_PAYLOAD_1 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 0, 0xff, 0, 0, 1, 0xff, 0, 0, 2, 0xff, 0, 0, 3, 0xff, 0, 0, 4, 0xff, 0, 0, 0}
+#define MOZA_BTN_COLOR_PAYLOAD_2 {0x7e, 0x16, 0x3f, 0x17, 0x19, 1, 5, 0xff, 0, 0, 6, 0xff, 0, 0, 7, 0xff, 0, 0, 8, 0xff, 0, 0, 9, 0xff, 0, 0, 0}
+#define MOZA_COLOR_PAYLOAD_SIZE 27
+#define BIT(nr) (1UL << (nr))
+
+int moza_ks_pro_wheel_update(SerialDevice* serialdevice, SimData* simData)
+{
+    unsigned char bytes[] = MOZA_RPM_MASK_TEMPLATE;
+    int size = MOZA_RPM_MASK_PAYLOAD_SIZE;
+    float perctflt = ((float)simData->rpms/(float)simData->maxrpm)*100;
+    int perct = round(perctflt);
+    if (perct >= 98 && (simData->mtick >> 7) & 1 == 1) perct = 0;
+
+    if (perct >= 75)
+        bytes[6] |= BIT(0);
+
+    if (perct >= 79)
+        bytes[6] |= BIT(1);
+
+    if (perct >= 82)
+        bytes[6] |= BIT(2);
+
+    if (perct >= 85)
+        bytes[6] |= BIT(3);
+
+    if (perct >= 87)
+        bytes[6] |= BIT(4);
+
+    if (perct >= 88)
+        bytes[6] |= BIT(5);
+
+    if (perct >= 89)
+        bytes[6] |= BIT(6);
+
+    if (perct >= 90)
+        bytes[6] |= BIT(7);
+
+    if (perct >= 92)
+        bytes[7] |= BIT(0);
+
+    if (perct >= 94)
+        bytes[7] |= BIT(1);
+
+    if (perct >= 95)
+        bytes[7] |= BIT(2);
+
+    if (perct >= 96)
+        bytes[7] |= BIT(3);
+
+    if (perct >= 97)
+        bytes[7] |= BIT(4);
+
+    if (perct >= 98)
+        bytes[7] |= BIT(5);
+
+    if (perct >= 99)
+        bytes[7] |= BIT(6);
+
+    bytes[10] = moza_checksum(bytes, size);
+
+    int result = 1;
+    if (serialdevice->port)
+    {
+        slogd("copying %i bytes to moza device", MOZA_RPM_MASK_PAYLOAD_SIZE);
+        slogt("writing bytes %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x from rpm %i maxrpm %i", bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], simData->rpms, simData->maxrpm);
+        result = monocoque_serial_write(serialdevice->id, bytes, size, MOZA_TIMEOUT);
+    }
+
+    return result;
+}
+
+int moza_ks_pro_wheel_init(SerialDevice* serialdevice, const char* portdev)
+{
+    serialdevice->id = monocoque_serial_open(serialdevice, portdev);
+    if (serialdevice->id == -1) return serialdevice->id;
+
+    unsigned char p1[] = MOZA_RPM_COLOR_PAYLOAD_1;
+    unsigned char p2[] = MOZA_RPM_COLOR_PAYLOAD_2;
+    unsigned char p3[] = MOZA_RPM_COLOR_PAYLOAD_3;
+    unsigned char p4[] = MOZA_BTN_COLOR_PAYLOAD_1;
+    unsigned char p5[] = MOZA_BTN_COLOR_PAYLOAD_2;
+
+    p1[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p1, MOZA_COLOR_PAYLOAD_SIZE);
+    p2[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p2, MOZA_COLOR_PAYLOAD_SIZE);
+    p3[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p3, MOZA_COLOR_PAYLOAD_SIZE);
+    p4[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p4, MOZA_COLOR_PAYLOAD_SIZE);
+    p5[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p5, MOZA_COLOR_PAYLOAD_SIZE);
+
+    monocoque_serial_write(serialdevice->id, p1, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p2, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p3, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p4, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    monocoque_serial_write(serialdevice->id, p5, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+
+    return serialdevice->id;
+}

--- a/src/monocoque/devices/serial/moza_ks_pro_wheel.h
+++ b/src/monocoque/devices/serial/moza_ks_pro_wheel.h
@@ -1,0 +1,10 @@
+#ifndef _MOZA_KS_PRO_WHEEL_H
+#define _MOZA_KS_PRO_WHEEL_H
+
+#include "../serialdevice.h"
+#include "../simdevice.h"
+
+int moza_ks_pro_wheel_update(SerialDevice* serialdevice, SimData* simData);
+int moza_ks_pro_wheel_init(SerialDevice* serialdevice, const char* portdev);
+
+#endif

--- a/src/monocoque/devices/serialdevice.c
+++ b/src/monocoque/devices/serialdevice.c
@@ -11,6 +11,7 @@
 #include "serial/arduino.h"
 #include "serial/moza.h"
 #include "serial/moza_new.h"
+#include "serial/moza_ks_pro_wheel.h"
 #include "../helper/parameters.h"
 #include "../simulatorapi/simapi/simapi/simdata.h"
 #include "../slog/slog.h"
@@ -24,6 +25,10 @@ int serial_wheel_update(SimDevice* this, SimData* simdata)
     switch (serialdevice->devicetype) {
       case SIMDEVSUBTYPE_MOZA_NEW:
         moza_new_update(serialdevice, simdata);
+        break;
+
+      case SERIALDEV__MOZA_KS_PRO_WHEEL:
+        moza_ks_pro_wheel_update(serialdevice, simdata);
         break;
 
       case SIMDEVSUBTYPE_MOZAR5:
@@ -240,6 +245,9 @@ int serialdev_init(SerialDevice* serialdevice, DeviceSettings* ds, SimInfo* simi
         case SERIALDEV__MOZA_NEW:
             error = moza_new_init(serialdevice, ds->serialdevsettings.portdev);
             break;
+        case SERIALDEV__MOZA_KS_PRO_WHEEL:
+            error = moza_ks_pro_wheel_init(serialdevice, ds->serialdevsettings.portdev);
+            break;
         case ARDUINODEV__SIMLED__CUSTOM:
             serialdevice->m.device_specific_config_file = strdup(ds->specific_config_file);
             error = arduino_custom_init(serialdevice, ds->serialdevsettings.portdev, serialdevice->m.device_specific_config_file, true);
@@ -355,6 +363,11 @@ SerialDevice* new_serial_device(DeviceSettings* ds, MonocoqueSettings* ms, SimIn
                 case SIMDEVSUBTYPE_MOZA_NEW:
                   slogi("Initializing new firmware Moza serial wheel device.");
                   this->devicetype = SERIALDEV__MOZA_NEW;
+                  this->m.vtable = &serialwheel_vtable;
+                  break;
+                case SIMDEVSUBTYPE_MOZA_KS_PRO_WHEEL:
+                  slogi("Initializing new firmware Moza serial wheel device.");
+                  this->devicetype = SERIALDEV__MOZA_KS_PRO_WHEEL;
                   this->m.vtable = &serialwheel_vtable;
                   break;
                 case SIMDEVSUBTYPE_MOZAR5:

--- a/src/monocoque/devices/serialdevice.h
+++ b/src/monocoque/devices/serialdevice.h
@@ -13,7 +13,8 @@ typedef enum
     ARDUINODEV__SIMLED                = 4,
     ARDUINODEV__SIMLED__CUSTOM        = 5,
     ARDUINODEV__CUSTOM                = 6,
-    SERIALDEV__MOZA_NEW               = 7
+    SERIALDEV__MOZA_NEW               = 7,
+    SERIALDEV__MOZA_KS_PRO_WHEEL      = 8
 }
 SerialDeviceType;
 

--- a/src/monocoque/helper/confighelper.c
+++ b/src/monocoque/helper/confighelper.c
@@ -118,6 +118,11 @@ int strtodevsubsubtype(const char* device_subsubtype, DeviceSettings* ds)
         ds->dev_subsubtype = SIMDEVSUBTYPE_MOZAR5;
         devfound = true;
     }
+    if (strcicmp(device_subsubtype, "MozaKSProWheel") == 0)
+    {
+        ds->dev_subsubtype = SIMDEVSUBTYPE_MOZA_KS_PRO_WHEEL;
+        devfound = true;
+    }
     if (strcicmp(device_subsubtype, "CSLELITEV3PEDALS") == 0)
     {
         ds->dev_subsubtype = SIMDEVSUBTYPE_CSLELITEV3PEDALS;

--- a/src/monocoque/helper/confighelper.h
+++ b/src/monocoque/helper/confighelper.h
@@ -45,7 +45,8 @@ typedef enum
     SIMDEVSUBTYPE_SIMAGICP1000PEDALS      = 5,
     SIMDEVSUBTYPE_SIMAGICGTNEO            = 6,
     SIMDEVSUBTYPE_MOZA_NEW                = 7,
-    SIMDEVSUBTYPE_LOGITECH_G29            = 8
+    SIMDEVSUBTYPE_LOGITECH_G29            = 8,
+    SIMDEVSUBTYPE_MOZA_KS_PRO_WHEEL       = 9
 }
 DeviceSubSubType;
 


### PR DESCRIPTION
This adds a new device for the combination of Moza R12 (not sure if that makes a difference) and a Moza KS Pro Wheel. 

Tested on hardware with a Moza KS Pro Wheel. RPM LEDs and yellow flag signaling confirmed working.

Documentation is added in https://github.com/Spacefreak18/simapi/pull/27. 

I'm not sure how it could be implemented without the device duplication etc. I guess it would be quite interesting to make the color choice etc configurable. Or whether to go by RPM instead of percentages or so. 


--- AI Generated Doc
Adds support for the Moza KS Pro Wheel as a serial device.
•New device driver (moza_ks_pro_wheel.c) implementing init and update functions
•On init, sends color configuration payloads to set RPM LED colors (green → yellow → red gradient) and button colors
•On update, drives 12 RPM shift-light LEDs proportionally from 75%–97% of max RPM, with a blink effect above 98%
•Yellow flag support: illuminates left and right flag LEDs amber when SIMAPI_FLAG_YELLOW is active, with flag LED color changes sent only when flag state transitions (not every tick)
•Config key: MozaKSProWheel (case-insensitive) in device settings