### PR TITLE
Fix multiple serial device init issues

### DIFF
--- a/src/monocoque/devices/serial/moza.c
+++ b/src/monocoque/devices/serial/moza.c
@@ -84,6 +84,8 @@ int moza_update(SerialDevice* serialdevice, unsigned short rpm, unsigned short m
 
 int moza_init(SerialDevice* serialdevice, const char* portdev)
 {
-    serialdevice->id = monocoque_serial_open(serialdevice, portdev);
-    return serialdevice->id;
+    int id = monocoque_serial_open(serialdevice, portdev);
+    if (id < 0) return id;
+    serialdevice->id = id;
+    return 0;
 }

--- a/src/monocoque/devices/serial/moza_new.c
+++ b/src/monocoque/devices/serial/moza_new.c
@@ -74,8 +74,9 @@ int moza_new_update(SerialDevice* serialdevice, SimData* simData)
 
 int moza_new_init(SerialDevice* serialdevice, const char* portdev)
 {
-    serialdevice->id = monocoque_serial_open(serialdevice, portdev);
-    if (serialdevice->id == -1) return serialdevice->id;
+    int id = monocoque_serial_open(serialdevice, portdev);
+    if (id < 0) return id;
+    serialdevice->id = id;
 
     unsigned char p1[] = MOZA_RPM_COLOR_PAYLOAD_1;
     unsigned char p2[] = MOZA_RPM_COLOR_PAYLOAD_2;
@@ -87,10 +88,11 @@ int moza_new_init(SerialDevice* serialdevice, const char* portdev)
     p3[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p3, MOZA_COLOR_PAYLOAD_SIZE);
     p4[MOZA_COLOR_PAYLOAD_SIZE-1] = moza_checksum(p4, MOZA_COLOR_PAYLOAD_SIZE);
 
-    monocoque_serial_write(serialdevice->id, p1, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
-    monocoque_serial_write(serialdevice->id, p2, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
-    monocoque_serial_write(serialdevice->id, p3, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
-    monocoque_serial_write(serialdevice->id, p4, MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+    unsigned char* payloads[] = {p1, p2, p3, p4};
+    for (int i = 0; i < 4; i++) {
+        int result = monocoque_serial_write(serialdevice->id, payloads[i], MOZA_COLOR_PAYLOAD_SIZE, MOZA_TIMEOUT);
+        if (result < 0) return result;
+    }
 
-    return serialdevice->id;
+    return 0;
 }

--- a/src/monocoque/devices/serialadapter.c
+++ b/src/monocoque/devices/serialadapter.c
@@ -27,10 +27,13 @@ int check(enum sp_return result)
             error_message = sp_last_error_message();
             sloge("error: serial write failed: %s", error_message);
             sp_free_error_message(error_message);
+            return result;
         case SP_ERR_SUPP:
             printf("Error: Not supported.\n");
+            return result;
         case SP_ERR_MEM:
             printf("Error: Couldn't allocate memory.\n");
+            return result;
         case SP_OK:
         default:
             return result;
@@ -114,23 +117,30 @@ int monocoque_input_wait(uint8_t serialdevicenum)
     return sp_input_waiting(monocoque_serial_dev.port);
 }
 
-int monocoque_serial_write(uint8_t serialdevicenum, void* data, size_t size, int timeout)
+// Helper function to get and validate device
+static monocoque_serial_device* monocoque_get_serial_device(uint8_t serialdevicenum)
 {
+    monocoque_serial_device* dev = &monocoque_serial_devices[serialdevicenum];
     slogt("serial device id %i", serialdevicenum);
-    monocoque_serial_device monocoque_serial_dev = monocoque_serial_devices[serialdevicenum];
-
-    slogt("port name: %s, busy %i, open %i, openfail %i", monocoque_serial_dev.portname, monocoque_serial_dev.busy, monocoque_serial_dev.open, monocoque_serial_dev.busy);
-
-    if(monocoque_serial_dev.port == NULL)
+    slogt("port name: %s, busy %i, open %i, openfail %i", dev->portname, dev->busy, dev->open, dev->openfail);
+    
+    if(dev->port == NULL)
     {
         sloge("port is null");
     }
+    
+    return dev;
+}
+
+int monocoque_serial_write(uint8_t serialdevicenum, void* data, size_t size, int timeout)
+{
+    monocoque_serial_device* dev = monocoque_get_serial_device(serialdevicenum);
 
     int result = -1;
-    if(monocoque_serial_dev.busy == false && monocoque_serial_dev.open == true)
+    if(dev->busy == false && dev->open == true)
     {
-        monocoque_serial_dev.busy = true;
-        result = sp_blocking_write(monocoque_serial_dev.port, data, size, timeout);
+        dev->busy = true;
+        result = sp_blocking_write(dev->port, data, size, timeout);
     }
     else
     {
@@ -138,67 +148,51 @@ int monocoque_serial_write(uint8_t serialdevicenum, void* data, size_t size, int
         result = -1;
     }
     slogt("write result is %i", result);
-    monocoque_serial_dev.busy = false;
+    dev->busy = false;
     return result;
 }
 
 int monocoque_serial_write_block(uint8_t serialdevicenum, void* data, size_t size, int timeout)
 {
-    slogt("serial device id %i", serialdevicenum);
-    monocoque_serial_device monocoque_serial_dev = monocoque_serial_devices[serialdevicenum];
-
-    slogt("port name: %s, busy %i, open %i, openfail %i", monocoque_serial_dev.portname, monocoque_serial_dev.busy, monocoque_serial_dev.open, monocoque_serial_dev.busy);
-
-    if(monocoque_serial_dev.port == NULL)
-    {
-        sloge("port is null");
-    }
+    monocoque_serial_device* dev = monocoque_get_serial_device(serialdevicenum);
 
     int result = -1;
-    if(monocoque_serial_dev.open == true)
+    if(dev->open == true)
     {
-        while(monocoque_serial_dev.busy == true)
+        while(dev->busy == true)
         {
             slogt("hopefully this doesn't happen long");
             continue;
         }
 
-        monocoque_serial_dev.busy = true;
-        result = sp_blocking_write(monocoque_serial_dev.port, data, size, timeout);
+        dev->busy = true;
+        result = sp_blocking_write(dev->port, data, size, timeout);
         slogi("actually performed write");
     }
 
-    monocoque_serial_dev.busy = false;
+    dev->busy = false;
     return result;
 }
 
 int monocoque_serial_read_block(uint8_t serialdevicenum, void* data, size_t size, int timeout)
 {
-    slogt("serial device id %i", serialdevicenum);
-    monocoque_serial_device monocoque_serial_dev = monocoque_serial_devices[serialdevicenum];
-
-    slogt("port name: %s, busy %i, open %i, openfail %i", monocoque_serial_dev.portname, monocoque_serial_dev.busy, monocoque_serial_dev.open, monocoque_serial_dev.busy);
-
-    if(monocoque_serial_dev.port == NULL)
-    {
-        sloge("port is null");
-    }
+    monocoque_serial_device* dev = monocoque_get_serial_device(serialdevicenum);
 
     int result = -1;
-    if(monocoque_serial_dev.open == true)
+    if(dev->open == true)
     {
-        while(monocoque_serial_dev.busy == true)
+        while(dev->busy == true)
         {
             slogt("hopefully this doesn't happen long");
             continue;
         }
 
-        monocoque_serial_dev.busy = true;
-        result = sp_blocking_read(monocoque_serial_dev.port, data, size, timeout);
+        dev->busy = true;
+        result = sp_blocking_read(dev->port, data, size, timeout);
         slogi("actually performed read");
     }
 
-    monocoque_serial_dev.busy = false;
+    dev->busy = false;
     return result;
 }
 

--- a/src/monocoque/helper/confighelper.c
+++ b/src/monocoque/helper/confighelper.c
@@ -715,7 +715,7 @@ int devsetup(const char* device_type, const char* device_subtype, const char* co
         }
     }
 
-    if (ds->dev_subtype == SIMDEVTYPE_USBHAPTIC || ds->dev_subtype == SIMDEVTYPE_USBWHEEL)
+    if (ds->dev_subtype == SIMDEVTYPE_USBHAPTIC || ds->dev_subtype == SIMDEVTYPE_USBWHEEL || ds->dev_subtype == SIMDEVTYPE_SERIALWHEEL)
     {
         // logic for different devices
         int b = 0;


### PR DESCRIPTION
I was setting up multiple serial devices (snippet of my config after this description), and saw that only one device worked at a time in my config, but not both. Also at one point I inadvertently had another process hogging my moza wheel so that it couldn't be cleanly init. Both these scenarios prompted me to look into the codebase and see if there was something that needed fixing. Found a few little things, and with these in place the config works great.

- The return code from `moza_init()` / `moza_new_init()` were returning the device id on success, but the caller treats that as an error (as it's looking for non zero as the error code). I've altered this to simply return 0 for success. In fact that also aligns with revburner_init().

- Added an early return on the serial_write failures, so we won't hide anything going wrong potentially (only a very minor cleanup really).

- The `monocoque_serial_device`s being referenced in the functions were local copies. This prevented the busy state from being synchonised in the case of multiple devices.

- The logging on errors were allowing fall-throughs to default, which while totally innocuous, still led to some confusing log messages coming out during investigation.

Config used:

```
configs = (
  {
    sim = "default";
    car = "default";
    devices = (
      {
        device   = "Serial";
        type     = "SimWind";
        config   = "None";
        baud     = 115200;
        devpath  = "/dev/arduino-wind";
        fanpower = 1.0;
      },
      {
        device  = "Serial";
        type    = "Wheel";
        subtype = "MozaNew";
        devpath = "/dev/moza-r5";
        baud    = 115200;
      },
```
