### PR TITLE
make additional data available to lua scripts

### DIFF
--- a/src/monocoque/devices/serial/arduinoledlua.c
+++ b/src/monocoque/devices/serial/arduinoledlua.c
@@ -64,6 +64,39 @@ int simdata_to_lua(lua_State *L, SimData* simdata) {
     }
     lua_setfield(L, -2, "pd");
 
+    lua_pushnumber(L, simdata->gas);
+    lua_setfield(L, -2, "gas");
+
+    lua_pushnumber(L, simdata->fuel);
+    lua_setfield(L, -2, "fuel");
+
+    lua_pushnumber(L, simdata->turboboost);
+    lua_setfield(L, -2, "turboboost");
+
+    lua_newtable(L);
+    for(int i = 0; i < 4; i++)
+    {
+        lua_pushnumber(L, simdata->tyreRPS[i]);
+        lua_rawseti(L, -2, i+1);
+    }
+    lua_setfield(L, -2, "tyreRPS");
+
+    lua_newtable(L);
+    for(int i = 0; i < 4; i++)
+    {
+        lua_pushnumber(L, simdata->tyrediameter[i]);
+        lua_rawseti(L, -2, i+1);
+    }
+    lua_setfield(L, -2, "tyrediameter");
+
+    lua_newtable(L);
+    for(int i = 0; i < 4; i++)
+    {
+        lua_pushnumber(L, simdata->tyretemp[i]);
+        lua_rawseti(L, -2, i+1);
+    }
+    lua_setfield(L, -2, "tyretemp");
+
     return 0; // Return the table to Lua
 }
 


### PR DESCRIPTION
adding a few variables that I'm using in my project.

@Spacefreak18 - a couple of questions:

1. would you like me to go ahead and add everything from simdata.h? Could we use a macro or similar to tidy up this code?
2. Should `rpm` be changed to `rpms` to remain consistent with simdata? Obviously this would be a breaking change for many end users, so I understand if it would be preferred to leave it as is.