### PR TITLE
create a rootful, privileged distrobox container

### DIFF
--- a/tools/distro/distrobox/install-distrobox.sh
+++ b/tools/distro/distrobox/install-distrobox.sh
@@ -122,6 +122,8 @@ if ! distrobox list 2>/dev/null | grep -q "$CONTAINER"; then
     distrobox create \
         --image docker.io/library/archlinux:latest \
         --name "$CONTAINER" \
+        --root \
+        --additional-flags "--privileged --security-opt seccomp=unconfined" \
         --pre-init-hooks "sed -i 's/^SigLevel.*/SigLevel = Never/' /etc/pacman.conf && pacman -Sy --noconfirm archlinux-keyring && pacman-key --init && pacman-key --populate archlinux && sed -i 's/^SigLevel.*/SigLevel = Required DatabaseOptional/' /etc/pacman.conf"
     log_success "Container '$CONTAINER' created"
 else
@@ -130,7 +132,7 @@ fi
 
 # Install packages inside the container
 log_info "Installing packages inside container (this may take a few minutes)..."
-distrobox enter "$CONTAINER" -- bash -c '
+distrobox enter --root "$CONTAINER" -- bash -c '
     set -euo pipefail
 
     # Install build dependencies
@@ -181,19 +183,19 @@ mkdir -p "$BIN_DIR"
 
 cat > "$BIN_DIR/start-simd" << 'EOF'
 #!/usr/bin/env bash
-exec distrobox enter simracing -- simd "$@"
+exec distrobox enter --root simracing -- simd "$@"
 EOF
 chmod +x "$BIN_DIR/start-simd"
 
 cat > "$BIN_DIR/start-monocoque" << 'EOF'
 #!/usr/bin/env bash
-exec distrobox enter simracing -- monocoque play "$@"
+exec distrobox enter --root simracing -- monocoque play "$@"
 EOF
 chmod +x "$BIN_DIR/start-monocoque"
 
 cat > "$BIN_DIR/test-monocoque" << 'EOF'
 #!/usr/bin/env bash
-exec distrobox enter simracing -- monocoque test -vv "$@"
+exec distrobox enter --root simracing -- monocoque test -vv "$@"
 EOF
 chmod +x "$BIN_DIR/test-monocoque"
 

--- a/tools/distro/distrobox/uninstall-distrobox.sh
+++ b/tools/distro/distrobox/uninstall-distrobox.sh
@@ -72,9 +72,9 @@ if [ -d "$INSTALL_DIR" ]; then
 fi
 
 # Remove distrobox container
-if distrobox list 2>/dev/null | grep -q "$CONTAINER"; then
+if distrobox list --root 2>/dev/null | grep -q "$CONTAINER"; then
     log_info "Removing distrobox container '$CONTAINER'..."
-    distrobox rm --force "$CONTAINER"
+    distrobox rm --root --force "$CONTAINER"
     log_success "Container '$CONTAINER' removed"
 else
     log_info "Container '$CONTAINER' not found, skipping"


### PR DESCRIPTION
On Bazzite, I was getting a warning when starting simd, where it could not access the /proc/<pid>/environ files. Working with Spacefreak18, we were able to determine that it was a permissions issue. Making the container rootful fixes that. We also found that simd was not able to connect to the bridge exe without being made privileged